### PR TITLE
Increase the precision of the random trader test

### DIFF
--- a/test/exchange_randomtrader.test.cpp
+++ b/test/exchange_randomtrader.test.cpp
@@ -7,7 +7,7 @@ using namespace snowhouse;
 using namespace bandit;
 using namespace exchange;
 
-const double EPS = 0.0001;
+const double EPS = 0.00001;
 
 go_bandit([]{
 describe("RandomTrader", []{


### PR DESCRIPTION
Addresses: https://github.com/nadvamir/trading-game/issues/19

The proper-proper fix is not to have random tests, but that's quite a lot of effort. The way this is structured, better precision should make the test virtually unfailable