### PR TITLE
add metrics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
+[submodule "statsd-c-client"]
+  path = statsd-c-client
+  url = https://github.com/romanbsd/statsd-c-client
 [submodule "bandit"]
 	path = bandit
 	url = https://github.com/banditcpp/bandit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required (VERSION 2.6)
+
+# main project
 project (FXBattle)
 
 find_package(Threads)
@@ -6,10 +8,14 @@ find_package(Threads)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++17 -pedantic -Wextra")
 find_package(Boost 1.52 COMPONENTS system thread REQUIRED)
 
+# statsd client library
+add_library(StatsDLibrary "${PROJECT_SOURCE_DIR}/statsd-c-client/statsd-client.c")
+
 # includes
 include_directories(".")
 include_directories("exchange")
 include_directories("fxbattle")
+include_directories("statsd-c-client")
 
 # test
 add_executable(Test.exe 
@@ -26,14 +32,14 @@ add_executable(Test.exe
 
 # service
 add_executable(FXBattle.exe 
-  ${PROJECT_SOURCE_DIR}/fxbattle/fxbattle_cachelessjsonresponse.h
   ${PROJECT_SOURCE_DIR}/fxbattle/fxbattle_configuration.cpp
-  ${PROJECT_SOURCE_DIR}/fxbattle/fxbattle_configuration.h
+  ${PROJECT_SOURCE_DIR}/fxbattle/fxbattle_metrics.cpp
   ${PROJECT_SOURCE_DIR}/fxbattle/fxbattle_main.cpp
 )
 
 target_link_libraries(FXBattle.exe ${Boost_LIBRARIES})
 target_link_libraries(FXBattle.exe ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(FXBattle.exe StatsDLibrary)
 
 # static files
 add_custom_command(OUTPUT index.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ copy exchange/          /source/exchange/
 copy templates/         /source/templates/
 copy test/              /source/test/
 copy fxbattle/          /source/fxbattle/
+copy statsd-c-client/   /source/statsd-c-client/
 
 # source files
 copy CMakeLists.txt Makefile /source/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,38 @@
 version: '2'
 services:
   fxbattle-app:
+    depends_on:
+      - graphite
     build: .
     volumes: 
       - .:/config
     ports:
       - "8080:8080"
+    networks:
+      - stats
+    environment:
+      - "ENV_STATSHOST=graphite"
+      - "ENV_STATSPORT=8125"
+
+  graphite:
+    image: hopsoft/graphite-statsd
+    networks:
+      - stats
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    networks:
+      - stats
+    volumes:
+      - "grafana-config:/var/lib/grafana"
+    environment:
+      - "GF_SERVER_ROOT_URL=http://james2.fxbattle.com:8088/"
+      - "GF_SECURITY_ADMIN_PASSWORD=thisisatest"
+
+networks:
+  stats:
+
+volumes:
+  grafana-config: 

--- a/exchange/exchange_brokerage.h
+++ b/exchange/exchange_brokerage.h
@@ -23,7 +23,8 @@ public:
     std::map<std::string, double> accounts_under_management(const std::string& reporting_ccy) const
     {
         std::map<std::string, double> report;
-        for (const auto& [_, account]: accounts) {
+        for (auto& account_entry: accounts) {
+            auto& account = account_entry.second; 
             report.insert({account->get_name(), account->get_value_in(reporting_ccy)});
         }
         return report;

--- a/fxbattle/fxbattle_metrics.cpp
+++ b/fxbattle/fxbattle_metrics.cpp
@@ -1,0 +1,4 @@
+#include <fxbattle/fxbattle_metrics.h>
+
+namespace fxbattle{
+}

--- a/fxbattle/fxbattle_metrics.h
+++ b/fxbattle/fxbattle_metrics.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <iostream>
+
+extern "C" {
+#include "statsd-client.h"
+}
+
+namespace fxbattle {
+
+class statsd {
+public:
+  class timing_scope{
+
+    using clock = std::chrono::high_resolution_clock;
+    statsd &_statsd;
+    const std::string &stat;
+    clock::time_point start;
+    bool finished = false;
+  public:
+    timing_scope(statsd &sd, std::string&&) = delete;
+
+    timing_scope(statsd &sd, const std::string& s)
+        : _statsd(sd), stat(s), start(clock::now()) 
+    {
+    }
+
+    ~timing_scope()
+    {
+      if (finished)
+        return;
+      auto end = clock::now();
+      auto elapsed =
+          std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+              .count();
+      _statsd.timing(stat, elapsed);
+    }
+
+    timing_scope(timing_scope&& ts):_statsd(ts._statsd), stat(ts.stat), start(ts.start){
+      ts.finished = true;
+    }
+  };
+
+private:
+  statsd_link *_link = nullptr;
+
+  void start_impl(const std::string &host, int port, const std::string &namesp) {
+    _link = statsd_init_with_namespace(const_cast<char *>(host.c_str()), port,
+                                       const_cast<char *>(namesp.c_str()));
+  }
+
+public:
+  bool start(const std::string &host, int port,
+             const std::string &namesp = "fxbattle") {
+    if (host.empty() || port <= 0)
+      return false;
+
+    std::cout << "logging stats to host: " << host << ':' << port << '\n';
+
+    start_impl(host, port, namesp);
+
+    return true;
+  }
+
+  ~statsd() {
+    if (!_link)
+      return;
+    statsd_finalize(_link);
+  }
+
+  int inc(const std::string &stat, float rate = 1.0f) {
+    if (!_link)
+      return 1;
+    return statsd_inc(_link, const_cast<char *>(stat.c_str()), rate);
+  }
+
+  int dec(const std::string &stat, float rate = 1.0f) {
+    if (!_link)
+      return 1;
+    return statsd_dec(_link, const_cast<char *>(stat.c_str()), rate);
+  }
+
+  int count(const std::string &stat, std::size_t count, float rate = 1.0f) {
+    if (!_link)
+      return 1;
+    return statsd_count(_link, const_cast<char *>(stat.c_str()), count, rate);
+  }
+
+  int gauge(const std::string &stat, std::size_t value) {
+    if (!_link)
+      return 1;
+    return statsd_gauge(_link, const_cast<char *>(stat.c_str()), value);
+  }
+
+  int timing(const std::string &stat, std::size_t timeunits) {
+    if (!_link)
+      return 1;
+    return statsd_timing(_link, const_cast<char *>(stat.c_str()), timeunits);
+  }
+
+  int timing(const std::string &stat, std::size_t timeunits, float rate) {
+    if (!_link)
+      return 1;
+    return statsd_timing_with_sample_rate(
+        _link, const_cast<char *>(stat.c_str()), timeunits, rate);
+  }
+};
+}
+
+


### PR DESCRIPTION
The docker compose file now starts a metrics gathering backend

The environment variables `ENV_STATSHOST` and `ENV_STATSPORT` allow the stats logging
to be controlled, if they are blank then it's disabled.

The environment variables in the docker compose should be modified before the
interface is made public (e.g. to add a non default password to the grafana frontend)